### PR TITLE
Revamp header controls and add zen mode

### DIFF
--- a/app.css
+++ b/app.css
@@ -15,7 +15,7 @@ body{
   color:var(--text); font:500 15px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;
 }
 
-.header{
+.header{ 
   position:sticky; top:0; z-index:50; display:flex; align-items:center; justify-content:space-between;
   padding:12px 18px; background:rgba(10,12,16,.7); backdrop-filter:blur(8px); border-bottom:1px solid #1e2530;
 }
@@ -23,6 +23,75 @@ body{
 .logo{display:inline-grid; place-items:center; width:26px; height:26px; border-radius:8px; background:var(--accent); color:#08101f; font-weight:900}
 .header h1{margin:0; font-size:18px; letter-spacing:.4px}
 .header-actions{display:flex; align-items:center; gap:10px}
+
+.btn-icon{
+  width:36px; height:36px;
+  border-radius:10px;
+  border:1px solid #2a3140;
+  background:var(--card-2);
+  color:var(--text);
+  display:inline-grid;
+  place-items:center;
+  font-size:18px;
+  cursor:pointer;
+  box-shadow:var(--shadow);
+  transition:background-color 120ms ease, border-color 120ms ease;
+}
+.btn-icon:hover{background:#232a3a; border-color:#39445a}
+.btn-icon:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+
+.overflow-menu{position:relative; display:inline-flex}
+.menu-panel{
+  position:absolute;
+  top:calc(100% + 10px);
+  right:0;
+  min-width:240px;
+  padding:8px;
+  border-radius:14px;
+  border:1px solid #273047;
+  background:var(--panel);
+  box-shadow:0 18px 48px rgba(0,0,0,.45);
+  display:grid;
+  gap:6px;
+  z-index:120;
+}
+.menu-panel.hidden{display:none}
+.menu-item{
+  appearance:none;
+  border:none;
+  width:100%;
+  border-radius:10px;
+  padding:10px 12px;
+  background:transparent;
+  color:var(--text);
+  display:flex;
+  align-items:center;
+  gap:12px;
+  cursor:pointer;
+  font:600 14px/1.3 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;
+  transition:background-color 120ms ease, color 120ms ease;
+}
+.menu-item:hover{background:#1f2432}
+.menu-item:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+.menu-item .menu-label{flex:1}
+.menu-item .menu-icon{font-size:16px; line-height:1}
+.menu-heading{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:.12em;
+  color:var(--muted);
+  padding:6px 4px 0;
+}
+.menu-group{
+  border-top:1px solid #232b3c;
+  padding-top:4px;
+  display:grid;
+  gap:6px;
+}
+.menu-meta{font-size:12px; color:var(--muted)}
+.menu-meta.active{color:var(--accent)}
+.menu-item.danger{color:var(--danger)}
+.menu-item.danger:hover{background:rgba(239,68,68,.15)}
 
 .btn{
   appearance:none; border:none; border-radius:10px; padding:8px 12px;
@@ -70,10 +139,12 @@ main{height:calc(100dvh - 58px); position:relative}
   border:1px solid #263046; border-radius:var(--radius); box-shadow:var(--shadow);
   display:flex; flex-direction:column; user-select:none; z-index:1;
 }
+.node.highlight{border-color:var(--accent-2); box-shadow:0 0 0 3px rgba(77,208,181,.4), var(--shadow)}
 .node .toolbar{
   display:flex; justify-content:space-between; align-items:center;
   padding:8px 10px; border-bottom:1px solid #232a3a; background:linear-gradient(180deg,#1a202a,#171c24);
   cursor:grab; border-top-left-radius:var(--radius); border-top-right-radius:var(--radius);
+  transition:opacity 140ms ease;
 }
 .node.dragging .toolbar{cursor:grabbing}
 .node .title{font-weight:700; font-size:13px; color:#cfe0ff}
@@ -185,6 +256,20 @@ main{height:calc(100dvh - 58px); position:relative}
   background: #1a2030; color: #9fb3d9;
   cursor: pointer;
 }
+
+/* Zen mode */
+body.zen-mode .mini-map,
+body.zen-mode .zoom-controls,
+body.zen-mode .canvas-toolbar,
+body.zen-mode .node .toolbar{opacity:0; pointer-events:none;}
+body.zen-mode .canvas:hover .mini-map,
+body.zen-mode .canvas:hover .zoom-controls,
+body.zen-mode .canvas:hover .canvas-toolbar,
+body.zen-mode .canvas:hover .node .toolbar,
+body.zen-mode .canvas:focus-within .mini-map,
+body.zen-mode .canvas:focus-within .zoom-controls,
+body.zen-mode .canvas:focus-within .canvas-toolbar,
+body.zen-mode .canvas:focus-within .node .toolbar{opacity:1; pointer-events:auto;}
 
 /* Connector handle for knowledge linking */
 .connector {

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@
 const API_BASE = "https://nodea-api.onrender.com";
 const LS_KEY = "OPENAI_KEY";
 const LS_BOARD = "NODEA_BOARD";
+const LS_ZEN = "NODEA_ZEN";
 const MODEL_DEFAULT = "gpt-4o-mini";
 const TOKEN_BUDGET_PAIRS = 6;
 
@@ -22,7 +23,7 @@ const state = {
     selection: new Set(),
     viewport: { x: 0, y: 0, zoom: 1 } // translate(x,y) and scale(zoom) applied to #stage
   },
-  ui: { running: false, lastContext: [], pendingConnect: null }, // pendingConnect: { srcId }
+  ui: { running: false, lastContext: [], pendingConnect: null, highlight: null, highlightTimer: null, zen: false }, // pendingConnect: { srcId }
   pan: { active: false, startX: 0, startY: 0, origX: 0, origY: 0 }
 };
 
@@ -53,9 +54,12 @@ const canvas = $("#canvas");
 const stage  = $("#stage");
 const edgesLayer = $("#edgesLayer");
 const keyChip = $("#keyChip");
-const btnSettings = $("#btnSettings");
-const btnContext  = $("#btnContext");
-const btnCenter   = $("#btnCenter");
+const btnSearch = $("#btnSearch");
+const btnQuickExport = $("#btnQuickExport");
+const btnOverflow = $("#btnOverflow");
+const menuOverflow = $("#menuOverflow");
+const contextStatus = $("#contextStatus");
+const zenStatus = $("#zenStatus");
 const modalSettings = $("#modalSettings");
 const inpKey = $("#inpKey");
 const inpModel = $("#inpModel");
@@ -65,19 +69,51 @@ const btnNewPrompt = $("#btnNewPrompt");
 const drawerContext = $("#drawerContext");
 const ctxList = $("#ctxList");
 const ctxCount = $("#ctxCount");
-const btnExport = $("#btnExport");
-const btnImport = $("#btnImport");
 const fileImport = $("#fileImport");
-const btnClear = $("#btnClear");
 const modalClear = $("#modalClear");
 const btnCancelClear = $("#btnCancelClear");
 const btnConfirmClear = $("#btnConfirmClear");
+let overflowOpen = false;
 
 /** RENDERERS **/
 function renderHeader(){
   const hasKey = !!keyGet();
-  keyChip.textContent = hasKey ? "Key: Set" : "Key: Missing";
-  keyChip.classList.toggle("muted", !hasKey);
+  if(keyChip){
+    keyChip.textContent = hasKey ? "Set" : "Missing";
+    keyChip.classList.toggle("muted", !hasKey);
+    keyChip.classList.toggle("active", hasKey);
+  }
+  if(contextStatus){
+    const open = !drawerContext.classList.contains("hidden");
+    contextStatus.textContent = open ? "On" : "Off";
+    contextStatus.classList.toggle("active", open);
+  }
+  if(zenStatus){
+    const on = !!state.ui.zen;
+    zenStatus.textContent = on ? "On" : "Off";
+    zenStatus.classList.toggle("active", on);
+  }
+}
+
+function applyZenMode(){
+  document.body.classList.toggle("zen-mode", state.ui.zen);
+}
+
+function setZenMode(on){
+  state.ui.zen = !!on;
+  applyZenMode();
+  localStorage.setItem(LS_ZEN, state.ui.zen ? "1" : "0");
+  renderHeader();
+  toast(state.ui.zen ? "Zen mode on." : "Zen mode off.", 1600);
+}
+
+function toggleZenMode(){
+  setZenMode(!state.ui.zen);
+}
+
+function loadZenMode(){
+  state.ui.zen = localStorage.getItem(LS_ZEN) === "1";
+  applyZenMode();
 }
 
 function applyViewport(){
@@ -92,7 +128,10 @@ function renderNodes(){
   for(const nodeId in state.board.nodes){
     const n = state.board.nodes[nodeId];
     const el = document.createElement("div");
-    el.className = `node ${n.type}${n.dragging ? " dragging":""}`;
+    const classes = ["node", n.type];
+    if(n.dragging) classes.push("dragging");
+    if(state.ui.highlight === n.id) classes.push("highlight");
+    el.className = classes.join(" ");
     el.style.left = (n.x||0) + "px";
     el.style.top  = (n.y||0) + "px";
     el.style.width = (n.w || 320) + "px";
@@ -285,6 +324,72 @@ function renderBoard(){
   renderHeader();
   applyViewport();
   renderNodes();
+}
+
+/** SEARCH & FOCUS **/
+function highlightNode(nodeId, { render = true } = {}){
+  if(state.ui.highlightTimer){
+    clearTimeout(state.ui.highlightTimer);
+    state.ui.highlightTimer = null;
+  }
+  state.ui.highlight = nodeId || null;
+  if(render) renderBoard();
+  if(nodeId){
+    state.ui.highlightTimer = setTimeout(()=>{
+      state.ui.highlight = null;
+      state.ui.highlightTimer = null;
+      renderBoard();
+    }, 2000);
+  }
+}
+
+function focusOnNode(nodeId){
+  const node = state.board.nodes[nodeId];
+  if(!node) return;
+
+  const vp = state.board.viewport;
+  const rect = canvas.getBoundingClientRect();
+  const w = node.w || 320;
+  const h = node.h || 140;
+  const z = vp.zoom;
+
+  const targetX = rect.width/2  - ((node.x||0) + w/2) * z;
+  const targetY = rect.height/2 - ((node.y||0) + h/2) * z;
+
+  vp.x = clamp(targetX, WORLD_BOUNDS.minX, WORLD_BOUNDS.maxX);
+  vp.y = clamp(targetY, WORLD_BOUNDS.minY, WORLD_BOUNDS.maxY);
+
+  saveBoard();
+  highlightNode(nodeId, { render: false });
+  renderBoard();
+}
+
+function openSearchDialog(){
+  const nodes = Object.values(state.board.nodes);
+  if(nodes.length === 0){
+    toast("No nodes on the board yet.");
+    return;
+  }
+
+  const input = prompt("Search nodes (matches prompt & response text):");
+  if(!input) return;
+
+  const query = input.trim().toLowerCase();
+  if(!query) return;
+
+  const match = nodes.find(n => {
+    const haystack = `${n.title || ""} ${n.content || ""} ${n.id || ""}`.toLowerCase();
+    return haystack.includes(query);
+  });
+
+  if(!match){
+    toast("No nodes matched your search.");
+    return;
+  }
+
+  focusOnNode(match.id);
+  const label = match.type === "prompt" ? "prompt" : (match.type === "response" ? "response" : "node");
+  toast(`Focused on ${label}.`, 1400);
 }
 
 /** DRAG - handle-only **/
@@ -612,6 +717,17 @@ async function exportBoard(){
   downloadBlob(blob, name);
   toast("Saved to your Downloads folder.");
 }
+
+async function copyBoardToClipboard(){
+  try{
+    const payload = JSON.stringify(serializeBoard(), null, 2);
+    await navigator.clipboard.writeText(payload);
+    toast("Workspace copied to clipboard.");
+  }catch(err){
+    console.warn("Clipboard copy failed", err);
+    toast("Copy failed. Check browser permissions.", 2400);
+  }
+}
 function importBoardFromFile(file){
   const r = new FileReader();
   r.onload = ()=>{
@@ -619,24 +735,40 @@ function importBoardFromFile(file){
       const data = JSON.parse(r.result);
       if(!data || !data.board) throw new Error("Invalid file.");
       state.board = data.board; state.board.selection = new Set();
+      if(state.ui.highlightTimer){
+        clearTimeout(state.ui.highlightTimer);
+        state.ui.highlightTimer = null;
+      }
+      state.ui.highlight = null;
       saveBoard(); renderBoard(); toast("Workspace imported.");
     }catch(e){ toast("Import failed: "+(e.message||e)); }
   };
   r.readAsText(file);
 }
-function openClearConfirm(){ modalClear.classList.remove("hidden"); modalClear.setAttribute("aria-hidden","false"); }
+function openClearConfirm(){
+  closeOverflowMenu();
+  modalClear.classList.remove("hidden");
+  modalClear.setAttribute("aria-hidden","false");
+}
 function closeClearConfirm(){ modalClear.classList.add("hidden"); modalClear.setAttribute("aria-hidden","true"); }
 function clearWorkspace(){
   state.board = { nodes:{}, edges:[], selection:new Set(), viewport:{ x:0, y:0, zoom:1 } };
+  if(state.ui.highlightTimer){
+    clearTimeout(state.ui.highlightTimer);
+    state.ui.highlightTimer = null;
+  }
+  state.ui.highlight = null;
   saveBoard(); renderBoard(); toast("Workspace cleared.");
 }
 
 /** UI - Settings / Context **/
 function openSettings(){
+  closeOverflowMenu();
   modalSettings.classList.remove("hidden");
   modalSettings.setAttribute("aria-hidden","false");
   inpKey.value = keyGet();
   if(inpModel) inpModel.value = MODEL_DEFAULT;
+  setTimeout(()=> inpKey?.focus(), 50);
 }
 function closeSettings(){
   modalSettings.classList.add("hidden");
@@ -653,11 +785,91 @@ function openContextDrawer(){
   drawerContext.classList.remove("hidden");
   drawerContext.setAttribute("aria-hidden","false");
   document.body.classList.add("drawer-open");
+  renderHeader();
 }
 function closeContextDrawer(){
   drawerContext.classList.add("hidden");
   drawerContext.setAttribute("aria-hidden","true");
   document.body.classList.remove("drawer-open");
+  renderHeader();
+}
+
+function toggleContextPanel(){
+  if(drawerContext.classList.contains("hidden")) openContextDrawer();
+  else closeContextDrawer();
+}
+
+function openOverflowMenu(){
+  if(!menuOverflow) return;
+  menuOverflow.classList.remove("hidden");
+  menuOverflow.setAttribute("aria-hidden","false");
+  btnOverflow?.setAttribute("aria-expanded","true");
+  overflowOpen = true;
+}
+
+function closeOverflowMenu(){
+  if(!menuOverflow) return;
+  menuOverflow.classList.add("hidden");
+  menuOverflow.setAttribute("aria-hidden","true");
+  btnOverflow?.setAttribute("aria-expanded","false");
+  overflowOpen = false;
+}
+
+function toggleOverflowMenu(){
+  if(overflowOpen) closeOverflowMenu();
+  else openOverflowMenu();
+}
+
+function handleOverflowAction(ev){
+  const target = ev.target.closest("[data-action]");
+  if(!target) return;
+  const action = target.dataset.action;
+
+  switch(action){
+    case "key":
+    case "settings":
+      openSettings();
+      break;
+    case "import":
+      closeOverflowMenu();
+      fileImport?.click();
+      break;
+    case "export-download":
+      closeOverflowMenu();
+      exportBoard();
+      break;
+    case "export-copy":
+      closeOverflowMenu();
+      copyBoardToClipboard();
+      break;
+    case "center":
+      closeOverflowMenu();
+      centerOnGraph();
+      break;
+    case "context":
+      closeOverflowMenu();
+      toggleContextPanel();
+      break;
+    case "zen":
+      closeOverflowMenu();
+      toggleZenMode();
+      break;
+    case "clear":
+      openClearConfirm();
+      break;
+  }
+}
+
+function handleGlobalClick(ev){
+  if(!overflowOpen) return;
+  if(menuOverflow?.contains(ev.target) || btnOverflow?.contains(ev.target)) return;
+  closeOverflowMenu();
+}
+
+function handleGlobalKeydown(ev){
+  if(ev.key === "Escape" && overflowOpen){
+    closeOverflowMenu();
+  }
 }
 
 /** Center on graph **/
@@ -709,34 +921,45 @@ function ensureFirstPrompt(){
 }
 
 function wireEvents(){
-  // Settings
-  btnSettings.onclick = openSettings;
-  $("[data-close-settings]").onclick = closeSettings;
-  btnSaveKey.onclick = ()=>{ keySet(inpKey.value.trim()); renderHeader(); closeSettings(); toast("Key saved."); };
-  btnClearKey.onclick = ()=>{ keySet(""); renderHeader(); closeSettings(); toast("Key cleared."); };
+  btnSearch?.addEventListener("click", ()=>{ closeOverflowMenu(); openSearchDialog(); });
+  btnQuickExport?.addEventListener("click", ()=>{ closeOverflowMenu(); exportBoard(); });
+  btnOverflow?.addEventListener("click", toggleOverflowMenu);
+  menuOverflow?.addEventListener("click", handleOverflowAction);
+  document.addEventListener("click", handleGlobalClick);
+  document.addEventListener("keydown", handleGlobalKeydown);
 
-  // Context
-  btnContext.onclick = openContextDrawer;
-  $("[data-close-context]").onclick = closeContextDrawer;
+  const closeSettingsBtn = $("[data-close-settings]");
+  closeSettingsBtn?.addEventListener("click", closeSettings);
+  btnSaveKey?.addEventListener("click", ()=>{
+    keySet(inpKey.value.trim());
+    renderHeader();
+    closeSettings();
+    toast("Key saved.");
+  });
+  btnClearKey?.addEventListener("click", ()=>{
+    keySet("");
+    renderHeader();
+    closeSettings();
+    toast("Key cleared.");
+  });
 
-  // Center
-  if(btnCenter) btnCenter.onclick = centerOnGraph;
+  const closeContextBtn = $("[data-close-context]");
+  closeContextBtn?.addEventListener("click", closeContextDrawer);
 
-  // New prompt
-  btnNewPrompt.onclick = ()=> createPromptNode(centerPoint());
+  btnNewPrompt?.addEventListener("click", ()=> createPromptNode(centerPoint()));
 
-  // Export / Import
-  btnExport.onclick = exportBoard;
-  btnImport.onclick = ()=> fileImport.click();
-  fileImport.onchange = (e)=>{ const f = e.target.files?.[0]; if(f) importBoardFromFile(f); e.target.value=""; };
+  if(fileImport){
+    fileImport.onchange = (e)=>{
+      const f = e.target.files?.[0];
+      if(f) importBoardFromFile(f);
+      e.target.value="";
+    };
+  }
 
-  // Clear workspace
-  btnClear.onclick = openClearConfirm;
-  btnCancelClear.onclick = closeClearConfirm;
-  $("[data-close-clear]").onclick = closeClearConfirm;
-  btnConfirmClear.onclick = ()=>{ closeClearConfirm(); clearWorkspace(); };
+  btnCancelClear?.addEventListener("click", closeClearConfirm);
+  $("[data-close-clear]")?.addEventListener("click", closeClearConfirm);
+  btnConfirmClear?.addEventListener("click", ()=>{ closeClearConfirm(); clearWorkspace(); });
 
-  // Pan on empty background and cancel pending connector
   canvas.addEventListener("pointerdown", (e)=>{
     if(e.target === canvas || e.target === stage){
       state.board.selection.clear?.();
@@ -747,14 +970,12 @@ function wireEvents(){
   window.addEventListener("pointermove", movePan);
   window.addEventListener("pointerup", endPan);
 
-  // Zoom anywhere over canvas
   canvas.addEventListener("wheel", onWheel, { passive:false });
-
-  // No keyboard shortcuts
 }
 
 function init(){
   loadBoard();
+  loadZenMode();
   renderHeader();
   ensureFirstPrompt();
   wireEvents();

--- a/index.html
+++ b/index.html
@@ -13,15 +13,37 @@
     <h1>Nodea</h1>
   </div>
   <div class="header-actions">
-    <span id="keyChip" class="chip muted">Key: Missing</span>
-    <button id="btnSettings" class="btn">Settings</button>
-    <button id="btnContext" class="btn secondary">Context</button>
-    <button id="btnCenter"  class="btn secondary">Center</button>
-    <button id="btnExport"  class="btn secondary">Export</button>
-    <button id="btnImport"  class="btn secondary">Import</button>
-    <button id="btnClear"   class="btn danger">Clear</button>
-    <input id="fileImport" type="file" accept="application/json" style="display:none" />
+    <button id="btnSearch" class="btn-icon" type="button" aria-label="Search workspace" title="Search workspace">🔍</button>
+    <button id="btnQuickExport" class="btn-icon" type="button" aria-label="Export workspace" title="Export workspace">↗</button>
+    <div class="overflow-menu">
+      <button id="btnOverflow" class="btn-icon" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="menuOverflow" title="More actions">⋯</button>
+      <div id="menuOverflow" class="menu-panel hidden" role="menu" aria-hidden="true">
+        <button class="menu-item" type="button" data-action="key" role="menuitem">
+          <span class="menu-label">Key Set</span>
+          <span id="keyChip" class="menu-meta muted">Missing</span>
+        </button>
+        <button class="menu-item" type="button" data-action="import" role="menuitem">Import</button>
+        <div class="menu-group" role="none">
+          <div class="menu-heading" role="presentation">Export</div>
+          <button class="menu-item" type="button" data-action="export-download" role="menuitem">Download .nodea.json</button>
+          <button class="menu-item" type="button" data-action="export-copy" role="menuitem">Copy JSON to clipboard</button>
+        </div>
+        <button class="menu-item" type="button" data-action="center" role="menuitem">Center / Fit</button>
+        <button class="menu-item" type="button" data-action="context" role="menuitem">
+          <span class="menu-label">Context Panel</span>
+          <span id="contextStatus" class="menu-meta">Off</span>
+        </button>
+        <button class="menu-item" type="button" data-action="settings" role="menuitem">Settings</button>
+        <button class="menu-item" type="button" data-action="zen" role="menuitem">
+          <span class="menu-icon" aria-hidden="true">👁</span>
+          <span class="menu-label">Zen Mode</span>
+          <span id="zenStatus" class="menu-meta">Off</span>
+        </button>
+        <button class="menu-item danger" type="button" data-action="clear" role="menuitem">Clear Board</button>
+      </div>
+    </div>
   </div>
+  <input id="fileImport" type="file" accept="application/json" hidden />
 </header>
 
   <main>


### PR DESCRIPTION
## Summary
- Replace the header button row with compact search, quick export, and an overflow menu that consolidates board actions.
- Add quick search focusing, clipboard export, and menu wiring for settings, context, and clear actions.
- Introduce a Zen Mode toggle with styling that hides canvas toolbars until the workspace is hovered.

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d8637042288323b502d65c7350bce3