### PR TITLE
Redesign node cards and prompt FAB

### DIFF
--- a/app.css
+++ b/app.css
@@ -26,7 +26,7 @@
   --e: cubic-bezier(.22,.61,.36,1);
 
   --drawer-w: 360px;
-  --node-w: 320px;
+  --node-w: 520px;
 }
 
 * {
@@ -320,17 +320,23 @@ main {
 
 .node {
   position: absolute;
-  width: var(--node-w);
-  min-height: 96px;
+  min-height: 120px;
+  width: clamp(360px, var(--node-w), 720px);
+  max-width: 720px;
   background: var(--card);
   border: 1px solid var(--hairline);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
   user-select: none;
   z-index: 2;
-  transition: box-shadow var(--t-fast) var(--e), border-color var(--t-fast) var(--e), transform var(--t-fast) var(--e);
+  transition: border-color var(--t-fast) var(--e), box-shadow var(--t-fast) var(--e), transform var(--t-fast) var(--e), background-color var(--t-fast) var(--e);
+}
+
+.node:hover {
+  border-color: rgba(148, 163, 184, 0.5);
+  box-shadow: var(--shadow-md);
 }
 
 .node.highlight {
@@ -338,119 +344,272 @@ main {
   box-shadow: 0 0 0 3px rgba(79,70,229,0.18), var(--shadow-md);
 }
 
-.node .toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--hairline);
-  background: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(247,248,251,0.9));
-  cursor: grab;
-  border-top-left-radius: var(--r-md);
-  border-top-right-radius: var(--r-md);
-  transition: opacity var(--t-fast) var(--e);
+.node.selected {
+  outline: 1px solid rgba(79,70,229,0.24);
+  outline-offset: 0;
+  box-shadow: 0 0 0 2px rgba(79,70,229,0.12), var(--shadow-md);
 }
 
-.node.dragging .toolbar {
+.node.dragging {
+  box-shadow: 0 16px 36px rgba(15,23,42,0.18);
+}
+
+.node.menu-open {
+  z-index: 5;
+}
+
+.node-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 16px;
+  min-height: 32px;
+  border-bottom: 1px solid var(--hairline);
+  background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(247,248,251,0.88));
+  border-top-left-radius: var(--r-md);
+  border-top-right-radius: var(--r-md);
+  cursor: grab;
+}
+
+.node.dragging .node-header {
   cursor: grabbing;
 }
 
-.node .title {
-  font-weight: 700;
-  font-size: 14px;
-  color: var(--ink-2);
-}
-
-.node .body {
-  padding: 16px;
-  display: grid;
-  gap: 12px;
-}
-
-.node textarea {
-  width: 100%;
-  min-height: 96px;
-  resize: vertical;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--hairline);
-  background: #f9faff;
-  color: var(--ink-2);
-  padding: 12px;
-  font: 500 14px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace;
-  transition: border-color var(--t-fast) var(--e), box-shadow var(--t-fast) var(--e);
-}
-
-.node textarea:focus {
-  outline: none;
-  border-color: rgba(79,70,229,0.4);
-  box-shadow: 0 0 0 3px rgba(79,70,229,0.12);
-}
-
-.node pre {
-  margin: 0;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  background: #f9faff;
-  padding: 12px;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--hairline);
-  color: var(--ink-2);
-  font: 500 13px/1.5 ui-monospace, Consolas, monospace;
-  max-height: 240px;
-  overflow: auto;
-}
-
-.node .row {
+.node-header-left {
   display: flex;
-  gap: 8px;
   align-items: center;
-}
-
-.node .row .spacer {
+  gap: 8px;
+  min-width: 0;
   flex: 1;
 }
 
-.node .badges {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.badge {
-  background: rgba(99, 102, 241, 0.12);
-  color: var(--brand);
-  font-size: 11px;
-  padding: 4px 10px;
+.node-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 600;
   border-radius: 999px;
-  border: 1px solid rgba(79,70,229,0.2);
-}
-
-.node.prompt .title {
+  border: 1px solid rgba(79,70,229,0.25);
+  background: rgba(79,70,229,0.12);
   color: var(--brand);
+  flex-shrink: 0;
 }
 
-.node.response .title {
-  color: #0f766e;
+.node-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 48ch;
+}
+
+.node-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.node-icon {
+  width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: var(--r-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--e), color var(--t-fast) var(--e), border-color var(--t-fast) var(--e);
+}
+
+.node-icon:hover {
+  background: rgba(15,23,42,0.06);
+  border-color: rgba(148,163,184,0.35);
+  color: var(--ink);
+}
+
+.node-icon:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.node-body {
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: max-height var(--t) var(--e), opacity var(--t) var(--e), padding var(--t) var(--e);
+}
+
+.node.collapsed .node-body {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  overflow: hidden;
+}
+
+.node-textarea {
+  width: 100%;
+  min-height: 120px;
+  resize: none;
+  border-radius: var(--r-sm);
+  border: 1px solid rgba(148,163,184,0.35);
+  background: #f6f8fc;
+  color: var(--ink-2);
+  padding: 12px 14px;
+  font: 500 15px/1.6 Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
+  transition: border-color var(--t-fast) var(--e), box-shadow var(--t-fast) var(--e);
+}
+
+.node-textarea:focus {
+  outline: none;
+  border-color: rgba(79,70,229,0.45);
+  box-shadow: 0 0 0 3px rgba(79,70,229,0.12);
+}
+
+.node-body-content {
+  position: relative;
+  overflow: hidden;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--ink-2);
+  white-space: pre-wrap;
+  transition: max-height var(--t) var(--e);
+}
+
+.node-body-content.is-clamped::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 48px;
+  background: linear-gradient(180deg, rgba(246,248,252,0), rgba(246,248,252,0.96));
+  pointer-events: none;
+}
+
+.node-body-content p {
+  margin: 0;
+}
+
+.node-body-content p + p {
+  margin-top: 12px;
+}
+
+.node-body-content ul,
+.node-body-content ol {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+}
+
+.node-body-content pre,
+.node-body-content code,
+.node-body-content blockquote {
+  background: #F6F8FC;
+  border-radius: var(--r-xs);
+  padding: 12px;
+  border: 1px solid rgba(148,163,184,0.25);
+  color: var(--ink-2);
+}
+
+.node-body-content pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font: 500 13px/1.5 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.node-body-content blockquote {
+  margin: 0;
+  font-style: italic;
+}
+
+.node-toggle {
+  border: none;
+  background: transparent;
+  color: var(--brand);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 0;
+  font-size: 14px;
+}
+
+.node-toggle:hover {
+  text-decoration: underline;
+}
+
+.node-menu {
+  position: absolute;
+  top: 44px;
+  right: 16px;
+  min-width: 190px;
+  padding: 10px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--hairline);
+  background: var(--card);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 6px;
+  z-index: 12;
+}
+
+.node-menu.hidden {
+  display: none;
+}
+
+.node-menu button {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: var(--r-sm);
+  color: var(--ink-2);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--e), color var(--t-fast) var(--e);
+}
+
+.node-menu button:hover {
+  background: #f0f3fb;
+  color: var(--ink);
+}
+
+.node-menu button:disabled {
+  color: var(--ink-3);
+  cursor: default;
 }
 
 .fab {
   position: absolute;
-  right: 24px;
-  bottom: 24px;
-  border-radius: 999px;
-  padding: 16px 20px;
-  font-weight: 700;
+  right: 32px;
+  bottom: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  min-width: 44px;
+  padding: 0 18px;
+  border-radius: var(--r-lg);
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.01em;
   background: var(--brand);
-  color: white;
+  color: #fff;
   box-shadow: var(--shadow-md);
   border: none;
   cursor: pointer;
-  transition: box-shadow var(--t-fast) var(--e), transform var(--t-fast) var(--e);
+  transition: box-shadow var(--t-fast) var(--e), transform var(--t-fast) var(--e), opacity var(--t-fast) var(--e);
 }
 
 .fab:hover {
-  box-shadow: 0 8px 28px rgba(79,70,229,0.2);
-  transform: translateY(-1px);
+  box-shadow: 0 10px 32px rgba(79,70,229,0.24);
+  transform: translateY(-2px);
 }
 
 .guide-line {
@@ -643,17 +802,6 @@ main {
   cursor: grabbing;
 }
 
-.toolbar .title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.toolbar .title .drag-handle::after {
-  content: "⋮";
-  line-height: 1;
-}
-
 .drawer-open .header {
   padding-right: calc(24px + var(--drawer-w));
 }
@@ -663,53 +811,13 @@ main {
 }
 
 .drawer-open .fab {
-  right: calc(24px + var(--drawer-w));
-}
-
-.node .body {
-  transition: max-height var(--t) var(--e), opacity var(--t) var(--e);
-  max-height: 800px;
-  opacity: 1;
-  overflow: hidden;
-}
-
-.node.collapsed .body {
-  max-height: 0;
-  opacity: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border: 0;
-}
-
-.node .preview {
-  display: none;
-  padding: 12px 16px;
-  color: var(--ink-2);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  border-top: 1px solid var(--hairline);
-}
-
-.node.collapsed .preview {
-  display: block;
-}
-
-.icon-btn.chev {
-  width: 28px;
-  height: 26px;
-  display: inline-grid;
-  place-items: center;
-  border-radius: var(--r-xs);
-  border: 1px solid var(--hairline);
-  background: #eef1fb;
-  color: var(--ink-3);
-  cursor: pointer;
+  right: calc(32px + var(--drawer-w));
 }
 
 .minimap {
   position: absolute;
-  right: 32px;
+  left: 32px;
+  right: auto;
   bottom: 32px;
   width: 220px;
   border-radius: 12px;
@@ -760,17 +868,25 @@ main {
 }
 
 body.zen-mode .header,
-body.zen-mode .minimap,
-body.zen-mode .fab {
+body.zen-mode .minimap {
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--t-fast) var(--e);
 }
 
 body.zen-mode:hover .header,
-body.zen-mode:hover .minimap,
-body.zen-mode:hover .fab {
+body.zen-mode:hover .minimap {
   opacity: 1;
   pointer-events: auto;
+}
+
+body.zen-mode .fab {
+  opacity: 0.6;
+  pointer-events: auto;
+}
+
+body.zen-mode .fab:hover,
+body.zen-mode:hover .fab:hover {
+  opacity: 1;
 }
 

--- a/app.js
+++ b/app.js
@@ -9,6 +9,13 @@ const LS_BOARD = "NODEA_BOARD";
 const LS_ZEN = "NODEA_ZEN";
 const MODEL_DEFAULT = "gpt-4o-mini";
 const TOKEN_BUDGET_PAIRS = 6;
+const NODE_WIDTH_DEFAULT = 520;
+const NODE_WIDTH_MIN = 360;
+const NODE_WIDTH_MAX = 720;
+const NODE_HEIGHT_DEFAULT = 200;
+const NODE_VERTICAL_OFFSET = NODE_HEIGHT_DEFAULT + 40;
+const NODE_HORIZONTAL_OFFSET = NODE_WIDTH_DEFAULT + 120;
+const NODE_CLAMP_LINES = 12;
 
 // Pan/Zoom limits
 const ZOOM_MIN = 0.5;
@@ -91,6 +98,8 @@ let minimapBounds = null;
 let minimapScale = 1;
 let minimapActivityTimer = null;
 const minimapNodeEls = new Map();
+let nodeResizeObserver = null;
+let activeNodeMenu = null;
 
 /** RENDERERS **/
 function renderHeader(){
@@ -140,8 +149,16 @@ function applyViewport(){
 }
 
 function renderNodes(){
-  // Clear existing nodes
-  $$(".node", stage).forEach(n => n.remove());
+  $$(".node", stage).forEach(n => {
+    if(nodeResizeObserver){
+      nodeResizeObserver.unobserve(n);
+    }
+    n.remove();
+  });
+
+  closeActiveNodeMenu();
+  ensureNodeResizeObserver();
+  nodeResizeObserver?.disconnect();
 
   for(const nodeId in state.board.nodes){
     const n = state.board.nodes[nodeId];
@@ -149,124 +166,157 @@ function renderNodes(){
     const classes = ["node", n.type];
     if(n.dragging) classes.push("dragging");
     if(state.ui.highlight === n.id) classes.push("highlight");
+    if(n.meta?.collapsed) classes.push("collapsed");
     el.className = classes.join(" ");
-    el.style.left = (n.x||0) + "px";
-    el.style.top  = (n.y||0) + "px";
-    el.style.width = (n.w || 320) + "px";
     el.dataset.id = n.id;
 
-    // Toolbar
-    const bar = document.createElement("div");
-    bar.className = "toolbar";
+    const width = clamp(n.w || NODE_WIDTH_DEFAULT, NODE_WIDTH_MIN, NODE_WIDTH_MAX);
+    n.w = width;
+    el.style.left = `${n.x || 0}px`;
+    el.style.top = `${n.y || 0}px`;
+    el.style.width = `${width}px`;
 
-    const title = document.createElement("div");
-    title.className = "title";
+    const header = document.createElement("div");
+    header.className = "node-header";
 
-    // Drag handle
-    const drag = document.createElement("span");
-    drag.className = "drag-handle";
-    title.appendChild(drag);
+    const headerLeft = document.createElement("div");
+    headerLeft.className = "node-header-left";
 
-    const titleText = document.createElement("span");
-    titleText.textContent = n.type === "prompt" ? "Prompt" : (n.type === "response" ? "Response" : "Node");
+    const chip = document.createElement("span");
+    chip.className = "node-chip";
+    const chipLabel = n.meta?.model || (n.type === "prompt" ? (modelGet() || MODEL_DEFAULT) : MODEL_DEFAULT);
+    chip.textContent = chipLabel;
+    headerLeft.appendChild(chip);
 
-    // Collapse chevron
-    const btnChev = document.createElement("button");
-    btnChev.className = "icon-btn chev";
-    btnChev.title = (n.meta?.collapsed ? "Expand" : "Collapse");
-    btnChev.textContent = n.meta?.collapsed ? "▸" : "▾";
-    btnChev.onclick = (e)=>{
+    const titleEl = document.createElement("div");
+    titleEl.className = "node-title";
+    const titleText = (n.title || "").trim() || (n.type === "prompt" ? "Prompt" : "Response");
+    titleEl.textContent = titleText;
+    titleEl.title = titleText;
+    headerLeft.appendChild(titleEl);
+
+    header.appendChild(headerLeft);
+
+    const actions = document.createElement("div");
+    actions.className = "node-header-actions";
+
+    const btnBranch = document.createElement("button");
+    btnBranch.className = "node-icon";
+    btnBranch.type = "button";
+    btnBranch.title = "Branch";
+    btnBranch.textContent = "➜";
+    btnBranch.onclick = (e)=>{ e.stopPropagation(); manualBranch(n.id); };
+    actions.appendChild(btnBranch);
+
+    const btnCollapse = document.createElement("button");
+    btnCollapse.className = "node-icon";
+    btnCollapse.type = "button";
+    btnCollapse.title = n.meta?.collapsed ? "Expand" : "Collapse";
+    btnCollapse.textContent = n.meta?.collapsed ? "›" : "⌄";
+    btnCollapse.onclick = (e)=>{
       e.stopPropagation();
       n.meta = n.meta || {};
       n.meta.collapsed = !n.meta.collapsed;
       saveBoard();
       renderBoard();
     };
-    title.appendChild(btnChev);
-    title.appendChild(titleText);
+    actions.appendChild(btnCollapse);
 
-    const badges = document.createElement("div");
-    badges.className = "badges";
-    if(n.meta?.model) {
-      const b = document.createElement("span");
-      b.className = "badge";
-      b.textContent = n.meta.model;
-      badges.appendChild(b);
-    }
+    const btnMenu = document.createElement("button");
+    btnMenu.className = "node-icon";
+    btnMenu.type = "button";
+    btnMenu.title = "More";
+    btnMenu.textContent = "⋯";
+    btnMenu.setAttribute("aria-haspopup", "true");
+    btnMenu.setAttribute("aria-expanded", "false");
+    actions.appendChild(btnMenu);
 
-    const toolbarRight = document.createElement("div");
-    toolbarRight.className = "row";
-    const spacer = document.createElement("div"); spacer.className = "spacer";
+    header.appendChild(actions);
+    el.appendChild(header);
 
-    // Actions (Run on prompt; Branch on both; Knowledge connector on both)
+    const body = document.createElement("div");
+    body.className = "node-body";
+
     if(n.type === "prompt"){
-      const btnRun = document.createElement("button");
-      btnRun.className = "btn secondary";
-      btnRun.textContent = state.ui.running ? "Running…" : "Run";
-      btnRun.disabled = state.ui.running;
-      btnRun.onclick = (e)=>{ e.stopPropagation(); runPrompt(n.id); };
+      const ta = document.createElement("textarea");
+      ta.className = "node-textarea";
+      ta.placeholder = "Type your prompt…";
+      ta.value = n.content || "";
+      ta.addEventListener("pointerdown", e => e.stopPropagation());
+      ta.addEventListener("focus", e => e.stopPropagation());
+      ta.addEventListener("input", (e) => {
+        n.content = e.target.value;
+        autoSizeTextarea(ta);
+        saveBoard();
+      });
+      autoSizeTextarea(ta);
+      if(n.meta?.autofocus){
+        setTimeout(()=> ta.focus(), 0);
+        n.meta.autofocus = false;
+      }
+      body.appendChild(ta);
+    } else {
+      const contentWrap = document.createElement("div");
+      contentWrap.className = "node-body-content";
+      renderRichContent(contentWrap, n.content || "");
+      body.appendChild(contentWrap);
 
-      const btnBranch = document.createElement("button");
-      btnBranch.className = "btn";
-      btnBranch.textContent = "Branch";
-      btnBranch.title = "Branch (create next step)";
-      btnBranch.onclick = (e)=>{ e.stopPropagation(); manualBranch(n.id); };
+      const toggleBtn = document.createElement("button");
+      toggleBtn.type = "button";
+      toggleBtn.className = "node-toggle";
+      toggleBtn.textContent = n.meta?.expanded ? "Show less" : "Show more";
+      toggleBtn.onclick = (e)=>{
+        e.stopPropagation();
+        n.meta = n.meta || {};
+        n.meta.expanded = !n.meta.expanded;
+        saveBoard();
+        renderBoard();
+      };
 
-      toolbarRight.append(btnBranch, btnRun);
-    } else if(n.type === "response"){
-      const btnBranch = document.createElement("button");
-      btnBranch.className = "btn";
-      btnBranch.textContent = "Branch";
-      btnBranch.title = "Branch (create next step)";
-      btnBranch.onclick = (e)=>{ e.stopPropagation(); manualBranch(n.id); };
-      toolbarRight.append(btnBranch);
+      handleClamp(n, contentWrap, body, toggleBtn);
     }
 
-    // Knowledge connector (undirected network link)
-    const connector = document.createElement("div");
-    connector.className = "connector";
-    connector.title = "Connect knowledge (drag onto another node)";
-    connector.onpointerdown = (e)=>{
+    el.appendChild(body);
+
+    const menu = document.createElement("div");
+    menu.className = "node-menu hidden";
+
+    if(n.type === "prompt"){
+      const runItem = document.createElement("button");
+      runItem.type = "button";
+      runItem.textContent = state.ui.running ? "Running…" : "Run prompt";
+      runItem.disabled = !!state.ui.running;
+      runItem.onclick = (e)=>{
+        e.stopPropagation();
+        closeActiveNodeMenu();
+        if(!state.ui.running) runPrompt(n.id);
+      };
+      menu.appendChild(runItem);
+    }
+
+    const connectItem = document.createElement("button");
+    connectItem.type = "button";
+    connectItem.textContent = "Connect knowledge";
+    connectItem.onclick = (e)=>{
       e.stopPropagation();
+      closeActiveNodeMenu();
       state.ui.pendingConnect = { srcId: n.id };
       toast("Select another node to connect...");
     };
-    toolbarRight.append(connector);
+    menu.appendChild(connectItem);
 
-    bar.append(title, badges, spacer, toolbarRight);
-    el.appendChild(bar);
+    el.appendChild(menu);
 
-    // Body + Preview (collapsible)
-    const body = document.createElement("div");
-    body.className = "body";
+    btnMenu.onclick = (e)=>{
+      e.stopPropagation();
+      if(activeNodeMenu?.menu === menu){
+        closeActiveNodeMenu();
+      } else {
+        openNodeMenu(btnMenu, menu);
+      }
+    };
 
-    let previewText = "";
-    if(n.type === "prompt"){
-      const ta = document.createElement("textarea");
-      ta.placeholder = "Type your prompt…";
-      ta.value = n.content || "";
-      ta.oninput = (e) => { n.content = e.target.value; saveBoard(); };
-      body.appendChild(ta);
-      previewText = (n.content || "").trim();
-      if(n.meta?.autofocus){ setTimeout(()=> ta.focus(), 0); n.meta.autofocus = false; }
-    } else if(n.type === "response"){
-      const pre = document.createElement("pre");
-      pre.textContent = n.content || "";
-      body.appendChild(pre);
-      previewText = (n.content || "").trim();
-    }
-
-    const preview = document.createElement("div");
-    preview.className = "preview";
-    preview.textContent = previewText || (n.type === "prompt" ? "(empty prompt)" : "(empty response)");
-
-    el.appendChild(body);
-    el.appendChild(preview);
-
-    if(n.meta?.collapsed){ el.classList.add("collapsed"); }
-    else { el.classList.remove("collapsed"); }
-
-    // If releasing on this node while connector active -> make knowledge edge
+    el.addEventListener("pointerdown", () => closeActiveNodeMenu());
     el.addEventListener("pointerup", ()=>{
       const pending = state.ui.pendingConnect;
       if(pending && pending.srcId !== n.id){
@@ -286,10 +336,204 @@ function renderNodes(){
 
     stage.appendChild(el);
 
-    // DRAG - handle-only
-    enableDrag(el, n.id, drag);
+    if(nodeResizeObserver){
+      nodeResizeObserver.observe(el);
+    }
+
+    enableDrag(el, n.id, header);
   }
   renderEdges();
+}
+
+function ensureNodeResizeObserver(){
+  if(typeof ResizeObserver !== "function") return;
+  if(nodeResizeObserver) return;
+  nodeResizeObserver = new ResizeObserver(entries => {
+    for(const entry of entries){
+      const el = entry.target;
+      const id = el.dataset.id;
+      if(!id) continue;
+      const node = state.board.nodes[id];
+      if(!node) continue;
+      const rect = entry.contentRect;
+      const width = clamp(Math.round(rect.width), NODE_WIDTH_MIN, NODE_WIDTH_MAX);
+      const height = Math.max(Math.round(rect.height), NODE_HEIGHT_DEFAULT);
+      node.w = width;
+      node.h = height;
+      updateMinimapNodePosition(id, node.x || 0, node.y || 0, width, height);
+    }
+  });
+}
+
+function autoSizeTextarea(el){
+  if(!el) return;
+  el.style.height = "auto";
+  el.style.height = `${Math.max(el.scrollHeight, 120)}px`;
+}
+
+function renderRichContent(container, text){
+  if(!container) return;
+  container.innerHTML = "";
+  if(!text){
+    const p = document.createElement("p");
+    p.textContent = "(empty response)";
+    container.appendChild(p);
+    return;
+  }
+
+  const lines = text.split(/\r?\n/);
+  let paragraph = [];
+  let currentList = null;
+  let listTag = null;
+  let inCode = false;
+  let codeBuffer = [];
+
+  const flushParagraph = () => {
+    if(!paragraph.length) return;
+    const p = document.createElement("p");
+    p.textContent = paragraph.join(" ").trim();
+    container.appendChild(p);
+    paragraph = [];
+  };
+
+  const flushList = () => {
+    if(currentList){
+      container.appendChild(currentList);
+      currentList = null;
+      listTag = null;
+    }
+  };
+
+  const flushCode = () => {
+    const pre = document.createElement("pre");
+    pre.textContent = codeBuffer.join("\n");
+    container.appendChild(pre);
+    codeBuffer = [];
+    inCode = false;
+  };
+
+  for(const line of lines){
+    if(line.trim().startsWith("```")){
+      flushParagraph();
+      flushList();
+      if(inCode){
+        flushCode();
+      } else {
+        inCode = true;
+      }
+      continue;
+    }
+
+    if(inCode){
+      codeBuffer.push(line);
+      continue;
+    }
+
+    const trimmed = line.trim();
+    if(trimmed === ""){
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    const bulletMatch = line.match(/^\s*([*+-])\s+(.*)$/);
+    if(bulletMatch){
+      flushParagraph();
+      if(listTag !== "ul"){
+        flushList();
+        currentList = document.createElement("ul");
+        listTag = "ul";
+      }
+      const li = document.createElement("li");
+      li.textContent = bulletMatch[2].trim();
+      currentList.appendChild(li);
+      continue;
+    }
+
+    const orderedMatch = line.match(/^\s*(\d+)[.)]\s+(.*)$/);
+    if(orderedMatch){
+      flushParagraph();
+      if(listTag !== "ol"){
+        flushList();
+        currentList = document.createElement("ol");
+        listTag = "ol";
+      }
+      const li = document.createElement("li");
+      li.textContent = orderedMatch[2].trim();
+      currentList.appendChild(li);
+      continue;
+    }
+
+    const quoteMatch = line.match(/^\s*>+\s?(.*)$/);
+    if(quoteMatch){
+      flushParagraph();
+      flushList();
+      const blockquote = document.createElement("blockquote");
+      blockquote.textContent = quoteMatch[1];
+      container.appendChild(blockquote);
+      continue;
+    }
+
+    paragraph.push(trimmed);
+  }
+
+  if(inCode){
+    flushCode();
+  }
+
+  flushParagraph();
+  flushList();
+
+  if(container.childElementCount === 0){
+    const p = document.createElement("p");
+    p.textContent = text;
+    container.appendChild(p);
+  }
+}
+
+function handleClamp(node, contentEl, bodyEl, toggleBtn){
+  requestAnimationFrame(()=>{
+    if(!contentEl?.isConnected) return;
+    const styles = getComputedStyle(contentEl);
+    const lineHeight = parseFloat(styles.lineHeight) || 22;
+    const clampHeight = lineHeight * NODE_CLAMP_LINES;
+    const expanded = !!node.meta?.expanded;
+    const fullHeight = contentEl.scrollHeight;
+
+    if(expanded){
+      contentEl.style.maxHeight = `${fullHeight}px`;
+      contentEl.classList.remove("is-clamped");
+      toggleBtn.textContent = "Show less";
+      if(toggleBtn.parentElement !== bodyEl) bodyEl.appendChild(toggleBtn);
+    } else if(fullHeight > clampHeight + 2){
+      contentEl.style.maxHeight = `${clampHeight}px`;
+      contentEl.classList.add("is-clamped");
+      toggleBtn.textContent = "Show more";
+      if(toggleBtn.parentElement !== bodyEl) bodyEl.appendChild(toggleBtn);
+    } else {
+      contentEl.style.maxHeight = "";
+      contentEl.classList.remove("is-clamped");
+      if(toggleBtn.parentElement) toggleBtn.remove();
+    }
+  });
+}
+
+function openNodeMenu(button, menu){
+  if(!menu || !button) return;
+  closeActiveNodeMenu();
+  menu.classList.remove("hidden");
+  button.setAttribute("aria-expanded", "true");
+  const card = button.closest(".node");
+  card?.classList.add("menu-open");
+  activeNodeMenu = { button, menu, card };
+}
+
+function closeActiveNodeMenu(){
+  if(!activeNodeMenu) return;
+  activeNodeMenu.menu.classList.add("hidden");
+  activeNodeMenu.button.setAttribute("aria-expanded", "false");
+  activeNodeMenu.card?.classList.remove("menu-open");
+  activeNodeMenu = null;
 }
 
 function renderEdges(){
@@ -304,9 +548,11 @@ function renderEdges(){
     const src = nodes[e.src], dst = nodes[e.dst];
     if(!src || !dst) continue;
 
-    const srcX = (src.x||0) + (src.w||320)/2;
+    const srcWidth = src.w || NODE_WIDTH_DEFAULT;
+    const dstWidth = dst.w || NODE_WIDTH_DEFAULT;
+    const srcX = (src.x||0) + srcWidth/2;
     const srcY = (src.y||0) + 30;
-    const dstX = (dst.x||0) + (dst.w||320)/2;
+    const dstX = (dst.x||0) + dstWidth/2;
     const dstY = (dst.y||0) + 30;
 
     const path = document.createElementNS("http://www.w3.org/2000/svg","path");
@@ -326,9 +572,11 @@ function renderEdges(){
     const a = nodes[e.src], b = nodes[e.dst];
     if(!a || !b) continue;
 
-    const ax = (a.x||0) + (a.w||320)/2;
+    const aw = a.w || NODE_WIDTH_DEFAULT;
+    const bw = b.w || NODE_WIDTH_DEFAULT;
+    const ax = (a.x||0) + aw/2;
     const ay = (a.y||0) + 30;
-    const bx = (b.x||0) + (b.w||320)/2;
+    const bx = (b.x||0) + bw/2;
     const by = (b.y||0) + 30;
 
     const line = document.createElementNS("http://www.w3.org/2000/svg","path");
@@ -371,8 +619,8 @@ function updateAlignmentGuides(nodeId, x, y, w, h){
     if(!other) continue;
     const ox = other.x || 0;
     const oy = other.y || 0;
-    const ow = other.w || 320;
-    const oh = other.h || 140;
+    const ow = other.w || NODE_WIDTH_DEFAULT;
+    const oh = other.h || NODE_HEIGHT_DEFAULT;
     const otherX = [ox, ox + ow / 2, ox + ow];
     const otherY = [oy, oy + oh / 2, oy + oh];
 
@@ -433,8 +681,8 @@ function getBoardBounds(){
     return {
       minX: WORLD_BOUNDS.minX,
       minY: WORLD_BOUNDS.minY,
-      maxX: WORLD_BOUNDS.maxX + 320,
-      maxY: WORLD_BOUNDS.maxY + 320
+      maxX: WORLD_BOUNDS.maxX + NODE_WIDTH_MAX,
+      maxY: WORLD_BOUNDS.maxY + NODE_HEIGHT_DEFAULT
     };
   }
 
@@ -442,8 +690,8 @@ function getBoardBounds(){
   for(const id of ids){
     const node = nodes[id];
     if(!node) continue;
-    const w = node.w || 320;
-    const h = node.h || 140;
+    const w = node.w || NODE_WIDTH_DEFAULT;
+    const h = node.h || NODE_HEIGHT_DEFAULT;
     const x = node.x || 0;
     const y = node.y || 0;
     minX = Math.min(minX, x);
@@ -480,8 +728,8 @@ function renderMinimap(){
     if(!node) continue;
     const nodeEl = document.createElement("div");
     nodeEl.className = `minimap-node${node.type ? ` ${node.type}` : ""}`;
-    const nodeWidth = Math.max((node.w || 320) * minimapScale, 4);
-    const nodeHeight = Math.max((node.h || 140) * minimapScale, 4);
+    const nodeWidth = Math.max((node.w || NODE_WIDTH_DEFAULT) * minimapScale, 4);
+    const nodeHeight = Math.max((node.h || NODE_HEIGHT_DEFAULT) * minimapScale, 4);
     const left = ((node.x || 0) - minimapBounds.minX) * minimapScale;
     const top = ((node.y || 0) - minimapBounds.minY) * minimapScale;
     nodeEl.style.width = `${nodeWidth}px`;
@@ -586,8 +834,8 @@ function focusOnNode(nodeId){
 
   const vp = state.board.viewport;
   const rect = canvas.getBoundingClientRect();
-  const w = node.w || 320;
-  const h = node.h || 140;
+  const w = node.w || NODE_WIDTH_DEFAULT;
+  const h = node.h || NODE_HEIGHT_DEFAULT;
   const z = vp.zoom;
 
   const targetX = rect.width/2  - ((node.x||0) + w/2) * z;
@@ -659,8 +907,8 @@ function enableDrag(el, nodeId, handleEl){
     el.style.left = nx + "px";
     el.style.top  = ny + "px";
     node.x = nx; node.y = ny;
-    const width = node.w || 320;
-    const height = node.h || 140;
+    const width = node.w || NODE_WIDTH_DEFAULT;
+    const height = node.h || NODE_HEIGHT_DEFAULT;
     updateAlignmentGuides(nodeId, nx, ny, width, height);
     updateMinimapNodePosition(nodeId, nx, ny, width, height);
     renderEdges();
@@ -737,8 +985,8 @@ function onWheel(ev){
 function centerPoint(){
   const rect = canvas.getBoundingClientRect();
   const { x, y, zoom } = state.board.viewport;
-  const worldX = (rect.width/2 - x)/zoom - 160;
-  const worldY = (rect.height/2 - y)/zoom - 80;
+  const worldX = (rect.width/2 - x)/zoom - NODE_WIDTH_DEFAULT/2;
+  const worldY = (rect.height/2 - y)/zoom - NODE_HEIGHT_DEFAULT/2;
   return {
     x: clamp(snapToGrid(worldX), WORLD_BOUNDS.minX, WORLD_BOUNDS.maxX),
     y: clamp(snapToGrid(worldY), WORLD_BOUNDS.minY, WORLD_BOUNDS.maxY)
@@ -749,7 +997,7 @@ function createPromptNode(pos){
   const id = uid("prompt");
   const px = clamp(snapToGrid(pos?.x ?? 0), WORLD_BOUNDS.minX, WORLD_BOUNDS.maxX);
   const py = clamp(snapToGrid(pos?.y ?? 0), WORLD_BOUNDS.minY, WORLD_BOUNDS.maxY);
-  const p = { id, type:"prompt", title:"Prompt", content:"", x: px, y: py, w:320, h:140, meta:{ autofocus:true } };
+  const p = { id, type:"prompt", title:"Prompt", content:"", x: px, y: py, w: NODE_WIDTH_DEFAULT, h: NODE_HEIGHT_DEFAULT, meta:{ autofocus:true } };
   state.board.nodes[id] = p;
   saveBoard(); renderBoard();
   return id;
@@ -759,8 +1007,8 @@ function createResponseNode(parentId, text, meta={}){
   const parent = state.board.nodes[parentId];
   const id = uid("resp");
   const x = clamp(snapToGrid(parent.x||0), WORLD_BOUNDS.minX, WORLD_BOUNDS.maxX);
-  const y = clamp(snapToGrid((parent.y||0) + 160), WORLD_BOUNDS.minY, WORLD_BOUNDS.maxY);
-  const r = { id, type:"response", title:"Response", content: text, x, y, w:320, h:140, meta };
+  const y = clamp(snapToGrid((parent.y||0) + NODE_VERTICAL_OFFSET), WORLD_BOUNDS.minY, WORLD_BOUNDS.maxY);
+  const r = { id, type:"response", title:"Response", content: text, x, y, w: NODE_WIDTH_DEFAULT, h: NODE_HEIGHT_DEFAULT, meta };
   state.board.nodes[id] = r;
   state.board.edges.push({ id: uid("e"), src: parentId, dst: id, kind:"lineage" });
   saveBoard(); renderBoard();
@@ -774,8 +1022,8 @@ function branchFrom(nodeId){
 
   const id = uid("prompt");
   const p = {
-    id, type:"prompt", title:"Prompt", content:"", w:320, h:140,
-    x: clamp(snapToGrid((parent.x||0) + 300), WORLD_BOUNDS.minX, WORLD_BOUNDS.maxX),
+    id, type:"prompt", title:"Prompt", content:"", w: NODE_WIDTH_DEFAULT, h: NODE_HEIGHT_DEFAULT,
+    x: clamp(snapToGrid((parent.x||0) + NODE_HORIZONTAL_OFFSET), WORLD_BOUNDS.minX, WORLD_BOUNDS.maxX),
     y: clamp(snapToGrid(parent.y||0), WORLD_BOUNDS.minY, WORLD_BOUNDS.maxY),
     meta:{ autofocus:true }
   };
@@ -1136,7 +1384,7 @@ function centerOnGraph(){
   let minX=Infinity, minY=Infinity, maxX=-Infinity, maxY=-Infinity;
   for(const id of ids){
     const n = state.board.nodes[id];
-    const x = n.x||0, y = n.y||0, w = n.w||320, h = n.h||140;
+    const x = n.x||0, y = n.y||0, w = n.w||NODE_WIDTH_DEFAULT, h = n.h||NODE_HEIGHT_DEFAULT;
     minX = Math.min(minX, x); minY = Math.min(minY, y);
     maxX = Math.max(maxX, x + w); maxY = Math.max(maxY, y + h);
   }
@@ -1183,6 +1431,12 @@ function wireEvents(){
   menuOverflow?.addEventListener("click", handleOverflowAction);
   document.addEventListener("click", handleGlobalClick);
   document.addEventListener("keydown", handleGlobalKeydown);
+  document.addEventListener("pointerdown", (ev)=>{
+    if(!activeNodeMenu) return;
+    const { menu, button } = activeNodeMenu;
+    if(menu.contains(ev.target) || button.contains(ev.target)) return;
+    closeActiveNodeMenu();
+  });
 
   const closeSettingsBtn = $("[data-close-settings]");
   closeSettingsBtn?.addEventListener("click", closeSettings);

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         <!-- Nodes will be injected here -->
       </div>
     </div>
-    <button id="btnNewPrompt" class="fab">＋ New Prompt</button>
+    <button id="btnNewPrompt" class="fab" type="button" aria-label="Create new prompt">New</button>
   </main>
 
   <!-- Settings Modal -->


### PR DESCRIPTION
## Summary
- Restyle node cards with the new compact header, model chip, icon actions, and refined body typography
- Add rich text rendering, content clamping with "Show more", and auto-resizing prompt inputs driven by a ResizeObserver
- Update the prompt FAB, reposition the minimap, and tweak Zen mode visibility to match the latest design guidance

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d87b8ccc848323abfc12db9215d644